### PR TITLE
Fix buffering streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ const getHighWaterMark = (streams, objectMode) => {
 const endWhenStreamsDone = async (passThroughStream, streams) => {
 	try {
 		await Promise.all(streams.map(stream => finished(stream, {cleanup: true, readable: true, writable: false})));
-		passThroughStream.resume();
 		passThroughStream.end();
 	} catch (error) {
 		// This is the error thrown by `finished()` on `stream.destroy()`

--- a/test.js
+++ b/test.js
@@ -145,3 +145,18 @@ const testBufferSize = async (t, objectMode) => {
 
 test('Use the correct highWaterMark', testBufferSize, false);
 test('Use the correct highWaterMark, objectMode', testBufferSize, true);
+
+test('Buffers streams before consumption', async t => {
+	const inputStream = Readable.from('.');
+	const stream = mergeStreams([inputStream]);
+	await scheduler.yield();
+
+	t.is(inputStream.readableLength, 0);
+	t.false(inputStream.readableFlowing);
+	t.true(inputStream.destroyed);
+
+	t.is(stream.readableLength, 1);
+	t.is(stream.readableFlowing, null);
+	t.false(stream.destroyed);
+	t.is(await text(stream), '.');
+});


### PR DESCRIPTION
When the input streams end, the merged stream ends too.

However, the merged stream might still contain some data that has not been read yet. At the moment, that data is lost. This PR fixes this.