### PR TITLE
Allow adding/removing streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+coverage

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import {type Readable} from 'node:stream';
+
 /**
 Merges an array of [readable streams](https://nodejs.org/api/stream.html#readable-streams) and returns a new readable stream that emits data from the individual streams as it arrives.
 
@@ -18,4 +20,23 @@ for await (const chunk of stream) {
 }
 ```
 */
-export default function mergeStreams(streams: NodeJS.ReadableStream[]): NodeJS.ReadableStream;
+export default function mergeStreams(streams: Readable[]): MergedStreams;
+
+/**
+Single stream combining the output of multiple streams.
+*/
+export class MergedStreams extends Readable {
+	/**
+	Pipe a new readable stream.
+
+	This fails if `MergedStream` has already ended.
+	*/
+	add(stream: Readable): void;
+
+	/**
+	Unpipe a previously added stream.
+
+	The removed stream is not automatically ended.
+	*/
+	remove(stream: Readable): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export class MergedStream extends Readable {
 	add(stream: Readable): void;
 
 	/**
-	Unpipe a previously added stream.
+	Unpipe a stream previously added using either `mergeStreams(streams)` or `MergedStream.add(stream)`.
 
 	The removed stream is not automatically ended.
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ for await (const chunk of stream) {
 export default function mergeStreams(streams: Readable[]): MergedStream;
 
 /**
-Single stream combining the output of multiple streams.
+A single stream combining the output of multiple streams.
 */
 export class MergedStream extends Readable {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export class MergedStream extends Readable {
 	/**
 	Pipe a new readable stream.
 
-	This fails if `MergedStream` has already ended.
+	Throws if `MergedStream` has already ended.
 	*/
 	add(stream: Readable): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,12 +20,12 @@ for await (const chunk of stream) {
 }
 ```
 */
-export default function mergeStreams(streams: Readable[]): MergedStreams;
+export default function mergeStreams(streams: Readable[]): MergedStream;
 
 /**
 Single stream combining the output of multiple streams.
 */
-export class MergedStreams extends Readable {
+export class MergedStream extends Readable {
 	/**
 	Pipe a new readable stream.
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class MergedStreams extends PassThroughStream {
 
 	remove(stream) {
 		if (!this.#streams.includes(stream)) {
-			throw new TypeError('Stream was not piped, so it cannot be removed.');
+			throw new TypeError('Stream cannot be removed because it was not piped.');
 		}
 
 		stream.unpipe(this);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ export default function mergeStreams(streams) {
 
 	const objectMode = streams.some(({readableObjectMode}) => readableObjectMode);
 	const highWaterMark = getHighWaterMark(streams, objectMode);
-	const passThroughStream = new MergedStreams({
+	const passThroughStream = new MergedStream({
 		objectMode,
 		writableHighWaterMark: highWaterMark,
 		readableHighWaterMark: highWaterMark,
@@ -41,7 +41,7 @@ const getHighWaterMark = (streams, objectMode) => {
 	return Math.max(...highWaterMarks);
 };
 
-class MergedStreams extends PassThroughStream {
+class MergedStream extends PassThroughStream {
 	#streams = [];
 	#ended = new Set([]);
 	#onComplete;

--- a/index.js
+++ b/index.js
@@ -54,12 +54,12 @@ class MergedStream extends PassThroughStream {
 	add(stream) {
 		validateStream(stream);
 
-		if (this.#streams.has(stream)) {
-			throw new TypeError('Stream cannot be added because it is already piped.');
-		}
-
 		if (!this.writable) {
 			throw new TypeError('The merged stream has already ended.');
+		}
+
+		if (this.#streams.has(stream)) {
+			return;
 		}
 
 		this.#streams.add(stream);

--- a/index.js
+++ b/index.js
@@ -52,12 +52,14 @@ class MergedStream extends PassThroughStream {
 	}
 
 	add(stream) {
+		validateStream(stream);
+
 		if (!this.writable) {
 			throw new TypeError('The merged stream has already ended.');
 		}
 
-		validateStream(stream);
 		this.#streams.push(stream);
+		this.#ended.delete(stream);
 		endWhenStreamsDone({passThroughStream: this, stream, streams: this.#streams, ended: this.#ended, onComplete: this.#onComplete});
 		updateMaxListeners(this, PASSTHROUGH_LISTENERS_PER_STREAM);
 		stream.pipe(this, {end: false});

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const endWhenStreamsDone = async ({passThroughStream, stream, streams, ended, on
 		try {
 			await Promise.race([
 				onComplete,
-				onInputStreamEnd(stream, streams, ended, abortController),
+				onInputStreamEnd({stream, streams, ended, abortController}),
 				onInputStreamUnpipe({passThroughStream, stream, streams, ended, abortController}),
 			]);
 		} finally {
@@ -137,7 +137,7 @@ const endWhenStreamsDone = async ({passThroughStream, stream, streams, ended, on
 	}
 };
 
-const onInputStreamEnd = async (stream, streams, ended, {signal}) => {
+const onInputStreamEnd = async ({stream, streams, ended, abortController: {signal}}) => {
 	await finished(stream, {signal, cleanup: true, readable: true, writable: false});
 	if (streams.has(stream)) {
 		ended.add(stream);

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const updateMaxListeners = (passThroughStream, increment) => {
 	passThroughStream.setMaxListeners(passThroughStream.getMaxListeners() + increment);
 };
 
-// Number of times `passThroughStream.on()` is called regardless of stream:
+// Number of times `passThroughStream.on()` is called regardless of streams:
 //  - once due to `finished(passThroughStream)`
 //  - once due to `on(passThroughStream)`
 const PASSTHROUGH_LISTENERS_COUNT = 2;

--- a/index.js
+++ b/index.js
@@ -92,18 +92,18 @@ const onMergedStreamEnd = async (passThroughStream, {signal}) => {
 	} catch {}
 };
 
-const validateStream = stream => {
-	if (typeof stream?.pipe !== 'function') {
-		throw new TypeError(`Expected a readable stream, got: \`${typeof stream}\`.`);
-	}
-};
-
 const onInputStreamsUnpipe = async (passThroughStream, streams, {signal}) => {
 	for await (const [unpipedStream] of on(passThroughStream, 'unpipe', {signal})) {
 		if (streams.includes(unpipedStream)) {
 			unpipedStream.emit(unpipeEvent);
 			updateMaxListeners(passThroughStream, -PASSTHROUGH_LISTENERS_PER_STREAM);
 		}
+	}
+};
+
+const validateStream = stream => {
+	if (typeof stream?.pipe !== 'function') {
+		throw new TypeError(`Expected a readable stream, got: \`${typeof stream}\`.`);
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,10 @@ class MergedStream extends PassThroughStream {
 	add(stream) {
 		validateStream(stream);
 
+		if (this.#streams.has(stream)) {
+			throw new TypeError('Stream cannot be added because it is already piped.');
+		}
+
 		if (!this.writable) {
 			throw new TypeError('The merged stream has already ended.');
 		}

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ const endWhenStreamsDone = async ({passThroughStream, stream, streams, ended, on
 			abortController.abort();
 		}
 
-		if ([...streams].every(stream => ended.has(stream)) && passThroughStream.writable) {
+		if (streams.size === ended.size && passThroughStream.writable) {
 			passThroughStream.end();
 		}
 	} catch (error) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import {setMaxListeners, on, once} from 'node:events';
-import {PassThrough as PassThroughStream} from 'node:stream';
+import {on, once} from 'node:events';
+import {PassThrough as PassThroughStream, getDefaultHighWaterMark} from 'node:stream';
 import {finished} from 'node:stream/promises';
 
 export default function mergeStreams(streams) {
@@ -7,34 +7,32 @@ export default function mergeStreams(streams) {
 		throw new TypeError(`Expected an array, got \`${typeof streams}\`.`);
 	}
 
-	const invalidStream = streams.find(stream => typeof stream?.pipe !== 'function');
-	if (invalidStream !== undefined) {
-		throw new TypeError(`Expected a readable stream, got: \`${typeof invalidStream}\`.`);
+	for (const stream of streams) {
+		validateStream(stream);
 	}
 
 	const objectMode = streams.some(({readableObjectMode}) => readableObjectMode);
 	const highWaterMark = getHighWaterMark(streams, objectMode);
-	const passThroughStream = new PassThroughStream({objectMode, writableHighWaterMark: highWaterMark, readableHighWaterMark: highWaterMark});
+	const passThroughStream = new MergedStreams({
+		objectMode,
+		writableHighWaterMark: highWaterMark,
+		readableHighWaterMark: highWaterMark,
+	});
+
+	for (const stream of streams) {
+		passThroughStream.add(stream);
+	}
 
 	if (streams.length === 0) {
 		passThroughStream.end();
-		return passThroughStream;
 	}
-
-	passThroughStream.setMaxListeners(passThroughStream.getMaxListeners() + getPassThroughListenersCount(streams));
-
-	for (const stream of streams) {
-		stream.pipe(passThroughStream, {end: false});
-	}
-
-	endWhenStreamsDone(passThroughStream, streams);
 
 	return passThroughStream;
 }
 
 const getHighWaterMark = (streams, objectMode) => {
 	if (streams.length === 0) {
-		return 0;
+		return getDefaultHighWaterMark(objectMode);
 	}
 
 	const highWaterMarks = streams
@@ -43,24 +41,86 @@ const getHighWaterMark = (streams, objectMode) => {
 	return Math.max(...highWaterMarks);
 };
 
-// Number of times `passThroughStream.on()` is called:
-//  - once per stream due to `stream.pipe(passThroughStream)`
-//  - once due to `finished(passThroughStream)`
-//  - once due to `on(passThroughStream)`
-const getPassThroughListenersCount = streams => streams.length + 2;
+class MergedStreams extends PassThroughStream {
+	#streams = [];
+	#ended = new Set([]);
+	#onComplete;
 
-const endWhenStreamsDone = async (passThroughStream, streams) => {
+	constructor(...args) {
+		super(...args);
+		this.#onComplete = onMergedStreamComplete(this, this.#streams);
+	}
+
+	add(stream) {
+		if (!this.writable) {
+			throw new TypeError('The merged stream has already ended.');
+		}
+
+		validateStream(stream);
+		this.#streams.push(stream);
+		endWhenStreamsDone({passThroughStream: this, stream, streams: this.#streams, ended: this.#ended, onComplete: this.#onComplete});
+		updateMaxListeners(this, PASSTHROUGH_LISTENERS_PER_STREAM);
+		stream.pipe(this, {end: false});
+	}
+
+	remove(stream) {
+		if (!this.#streams.includes(stream)) {
+			throw new TypeError('Stream was not piped, so it cannot be removed.');
+		}
+
+		stream.unpipe(this);
+	}
+}
+
+const onMergedStreamComplete = async (passThroughStream, streams) => {
+	updateMaxListeners(passThroughStream, PASSTHROUGH_LISTENERS_COUNT);
+	const abortController = new AbortController();
+	try {
+		await Promise.race([
+			onMergedStreamEnd(passThroughStream, abortController),
+			onInputStreamsUnpipe(passThroughStream, streams, abortController),
+		]);
+	} finally {
+		abortController.abort();
+		updateMaxListeners(passThroughStream, -PASSTHROUGH_LISTENERS_COUNT);
+	}
+};
+
+const onMergedStreamEnd = async (passThroughStream, {signal}) => {
+	try {
+		await finished(passThroughStream, {signal, cleanup: true});
+	} catch {}
+};
+
+const validateStream = stream => {
+	if (typeof stream?.pipe !== 'function') {
+		throw new TypeError(`Expected a readable stream, got: \`${typeof stream}\`.`);
+	}
+};
+
+const onInputStreamsUnpipe = async (passThroughStream, streams, {signal}) => {
+	for await (const [unpipedStream] of on(passThroughStream, 'unpipe', {signal})) {
+		if (streams.includes(unpipedStream)) {
+			unpipedStream.emit(unpipeEvent);
+			updateMaxListeners(passThroughStream, -PASSTHROUGH_LISTENERS_PER_STREAM);
+		}
+	}
+};
+
+const endWhenStreamsDone = async ({passThroughStream, stream, streams, ended, onComplete}) => {
 	try {
 		const abortController = new AbortController();
-		setMaxListeners(getSignalListenersCount(streams), abortController.signal);
 		try {
 			await Promise.race([
-				onMergedStreamEnd(passThroughStream, abortController),
-				onInputStreamsUnpipe(streams, passThroughStream, abortController),
-				onInputStreamsEnd(streams, passThroughStream, abortController),
+				onComplete,
+				onInputStreamEnd(stream, ended, abortController),
 			]);
 		} finally {
 			abortController.abort();
+		}
+
+		if (streams.every(stream => ended.has(stream)) && passThroughStream.writable) {
+			passThroughStream.end();
 		}
 	} catch (error) {
 		// This is the error thrown by `finished()` on `stream.destroy()`
@@ -72,36 +132,25 @@ const endWhenStreamsDone = async (passThroughStream, streams) => {
 	}
 };
 
-// Number of times `abortController.signal.on('abort')` is called. `signal` is used by:
-//  - each stream with both `finished()` and `once()`
-//  - `passThroughStream()` with both `finished()` and `on()`
-const getSignalListenersCount = streams => (streams.length * 2) + 2;
-
-const onMergedStreamEnd = async (passThroughStream, {signal}) => {
-	try {
-		await finished(passThroughStream, {signal, cleanup: true});
-	} catch {}
-};
-
-const onInputStreamsUnpipe = async (streams, passThroughStream, {signal}) => {
-	const streamsSet = new Set(streams);
-	for await (const [stream] of on(passThroughStream, 'unpipe', {signal})) {
-		if (streamsSet.has(stream)) {
-			stream.emit(unpipeEvent);
-		}
-	}
-};
-
-const onInputStreamsEnd = async (streams, passThroughStream, {signal}) => {
-	await Promise.all(streams.map(stream => onInputStreamEnd(stream, signal)));
-	passThroughStream.end();
-};
-
-const onInputStreamEnd = async (stream, signal) => {
+const onInputStreamEnd = async (stream, ended, {signal}) => {
 	await Promise.race([
 		finished(stream, {signal, cleanup: true, readable: true, writable: false}),
 		once(stream, unpipeEvent, {signal}),
 	]);
+	ended.add(stream);
 };
 
 const unpipeEvent = Symbol('unpipe');
+
+const updateMaxListeners = (passThroughStream, increment) => {
+	passThroughStream.setMaxListeners(passThroughStream.getMaxListeners() + increment);
+};
+
+// Number of times `passThroughStream.on()` is called regardless of stream:
+//  - once due to `finished(passThroughStream)`
+//  - once due to `on(passThroughStream)`
+const PASSTHROUGH_LISTENERS_COUNT = 2;
+
+// Number of times `passThroughStream.on()` is called per stream:
+//  - once due to `stream.pipe(passThroughStream)`
+const PASSTHROUGH_LISTENERS_PER_STREAM = 1;

--- a/index.js
+++ b/index.js
@@ -52,14 +52,14 @@ class MergedStream extends PassThroughStream {
 	}
 
 	add(stream) {
+		if (this.#streams.has(stream)) {
+			return;
+		}
+
 		validateStream(stream);
 
 		if (!this.writable) {
 			throw new TypeError('The merged stream has already ended.');
-		}
-
-		if (this.#streams.has(stream)) {
-			return;
 		}
 
 		this.#streams.add(stream);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,4 +22,3 @@ expectType<void>(mergedStream.remove(readableStream));
 expectError(mergedStream.remove());
 expectError(mergedStream.remove([]));
 expectError(mergedStream.remove(''));
-

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,10 @@
 import {Readable} from 'node:stream';
 import {expectType, expectError, expectAssignable} from 'tsd';
-import mergeStreams from './index.js';
+import mergeStreams, {type MergedStream} from './index.js';
 
 const readableStream = Readable.from('.');
 
+expectType<MergedStream>(mergeStreams([]));
 expectAssignable<Readable>(mergeStreams([]));
 expectAssignable<Readable>(mergeStreams([readableStream]));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,24 @@
+import {Readable} from 'node:stream';
+import {expectType, expectError, expectAssignable} from 'tsd';
+import mergeStreams from './index.js';
+
+const readableStream = Readable.from('.');
+
+expectAssignable<Readable>(mergeStreams([]));
+expectAssignable<Readable>(mergeStreams([readableStream]));
+
+expectError(mergeStreams());
+expectError(mergeStreams(readableStream));
+expectError(mergeStreams(['']));
+
+const mergedStream = mergeStreams([]);
+expectType<void>(mergedStream.add(readableStream));
+expectError(mergedStream.add());
+expectError(mergedStream.add([]));
+expectError(mergedStream.add(''));
+
+expectType<void>(mergedStream.remove(readableStream));
+expectError(mergedStream.remove());
+expectError(mergedStream.remove([]));
+expectError(mergedStream.remove(''));
+

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc index.d.ts"
+		"test": "xo && c8 ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -38,8 +38,11 @@
 		"unified"
 	],
 	"devDependencies": {
+		"@types/node": "^20.8.9",
 		"ava": "^6.1.0",
+		"c8": "^9.1.0",
 		"tempfile": "^5.0.0",
+		"tsd": "^0.30.4",
 		"typescript": "^5.2.2",
 		"xo": "^0.56.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ If you provide an empty array, it returns an already-ended stream.
 
 _Type_: `stream.Readable`
 
-Single stream combining the output of multiple streams.
+A single stream combining the output of multiple streams.
 
 ##### `MergedStream.add(stream: stream.Readable): void`
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Single stream combining the output of multiple streams.
 
 Pipe a new readable stream.
 
-This fails if `MergedStream` has already ended.
+Throws if `MergedStream` has already ended.
 
 ##### `MergedStream.remove(stream: stream.Readable): void`
 

--- a/readme.md
+++ b/readme.md
@@ -26,25 +26,25 @@ for await (const chunk of stream) {
 
 ## API
 
-### `mergeStreams(streams: stream.Readable[]): MergedStreams`
+### `mergeStreams(streams: stream.Readable[]): MergedStream`
 
 Merges an array of [readable streams](https://nodejs.org/api/stream.html#readable-streams) and returns a new readable stream that emits data from the individual streams as it arrives.
 
 If you provide an empty array, it returns an already-ended stream.
 
-#### `MergedStreams`
+#### `MergedStream`
 
 _Type_: `stream.Readable`
 
 Single stream combining the output of multiple streams.
 
-##### `MergedStreams.add(stream: stream.Readable): void`
+##### `MergedStream.add(stream: stream.Readable): void`
 
 Pipe a new readable stream.
 
 This fails if `MergedStream` has already ended.
 
-##### `MergedStreams.remove(stream: stream.Readable): void`
+##### `MergedStream.remove(stream: stream.Readable): void`
 
 Unpipe a previously added stream.
 

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,26 @@ for await (const chunk of stream) {
 
 ## API
 
-### `mergeStreams(streams: stream.Readable[]): stream.Readable`
+### `mergeStreams(streams: stream.Readable[]): MergedStreams`
 
 Merges an array of [readable streams](https://nodejs.org/api/stream.html#readable-streams) and returns a new readable stream that emits data from the individual streams as it arrives.
 
 If you provide an empty array, it returns an already-ended stream.
+
+#### `MergedStreams`
+
+_Type_: `stream.Readable`
+
+Single stream combining the output of multiple streams.
+
+##### `MergedStreams.add(stream: stream.Readable): void`
+
+Pipe a new readable stream.
+
+This fails if `MergedStream` has already ended.
+
+##### `MergedStreams.remove(stream: stream.Readable): void`
+
+Unpipe a previously added stream.
+
+The removed stream is not automatically ended.

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,6 @@ Throws if `MergedStream` has already ended.
 
 ##### `MergedStream.remove(stream: stream.Readable): void`
 
-Unpipe a previously added stream.
+Unpipe a stream previously added using either [`mergeStreams(streams)`](#mergestreamsstreams-streamreadable-mergedstream) or [`MergedStream.add(stream)`](#mergedstreamaddstream-streamreadable-void).
 
 The removed stream is not automatically ended.

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ import mergeStreams from './index.js';
 
 const getInfiniteStream = () => new Readable({read() {}});
 
-test('works with Readable.from()', async t => {
+test('Works with Readable.from()', async t => {
 	const stream = mergeStreams([
 		Readable.from(['a', 'b']),
 		Readable.from(['c', 'd']),
@@ -22,7 +22,7 @@ test('works with Readable.from()', async t => {
 
 const bigContents = '.'.repeat(1e6);
 
-test('works with fs.createReadStream()', async t => {
+test('Works with fs.createReadStream()', async t => {
 	const files = [tempfile(), tempfile()];
 	await Promise.all(files.map(file => writeFile(file, bigContents)));
 
@@ -41,7 +41,7 @@ test('Handles large values', async t => {
 	t.is(await text(stream), largeValue.repeat(largeRepeat));
 });
 
-test('propagate stream errors', async t => {
+test('Propagate stream errors', async t => {
 	const inputStream = getInfiniteStream();
 	const stream = mergeStreams([inputStream]);
 	const error = new Error('test');
@@ -55,7 +55,7 @@ test('propagate stream errors', async t => {
 	t.true(stream.destroyed);
 });
 
-test('propagate stream aborts', async t => {
+test('Propagate stream aborts', async t => {
 	const inputStream = getInfiniteStream();
 	const stream = mergeStreams([inputStream]);
 	inputStream.destroy();
@@ -67,7 +67,7 @@ test('propagate stream aborts', async t => {
 	t.true(stream.destroyed);
 });
 
-test('handles no input', async t => {
+test('Handles no input', async t => {
 	const stream = mergeStreams([]);
 	t.false(stream.readableObjectMode);
 	t.false(stream.writableObjectMode);
@@ -79,7 +79,7 @@ test('handles no input', async t => {
 	t.false(stream.readable);
 });
 
-test('cannot add stream after initially setting to no input', async t => {
+test('Cannot add stream after initially setting to no input', async t => {
 	const stream = mergeStreams([]);
 	t.throws(() => {
 		stream.add(Readable.from('.'));
@@ -87,19 +87,19 @@ test('cannot add stream after initially setting to no input', async t => {
 	await stream.toArray();
 });
 
-test('validates argument is an array', t => {
+test('Validates argument is an array', t => {
 	t.throws(() => {
 		mergeStreams(Readable.from('.'));
 	}, {message: /Expected an array/});
 });
 
-test('validates arguments are streams', t => {
+test('Validates arguments are streams', t => {
 	t.throws(() => {
 		mergeStreams([false]);
 	}, {message: /Expected a readable stream/});
 });
 
-test('validates add() argument is stream', t => {
+test('Validates add() argument is stream', t => {
 	t.throws(() => {
 		mergeStreams([Readable.from('.')]).add(false);
 	}, {message: /Expected a readable stream/});
@@ -114,11 +114,11 @@ const testObjectMode = async (t, firstObjectMode, secondObjectMode, mergeObjectM
 	await stream.toArray();
 };
 
-test('is not in objectMode if no input stream is', testObjectMode, false, false, false);
-test('is in objectMode if only some input streams are', testObjectMode, false, true, true);
-test('is in objectMode if all input streams are', testObjectMode, true, true, true);
+test('Is not in objectMode if no input stream is', testObjectMode, false, false, false);
+test('Is in objectMode if only some input streams are', testObjectMode, false, true, true);
+test('Is in objectMode if all input streams are', testObjectMode, true, true, true);
 
-test('add() cannot change objectMode', async t => {
+test('"add()" cannot change objectMode', async t => {
 	const stream = mergeStreams([Readable.from('.', {objectMode: false})]);
 	stream.add(Readable.from('.', {objectMode: true}));
 	t.false(stream.readableObjectMode);
@@ -278,11 +278,11 @@ const testHighWaterMarkAmount = async (t, firstObjectMode, secondObjectMode, hig
 	await stream.toArray();
 };
 
-test('highWaterMark is the maximum of non-object input streams', testHighWaterMarkAmount, false, false, 4);
-test('highWaterMark is the maximum of object input streams', testHighWaterMarkAmount, true, true, 4);
-test('highWaterMark is the maximum of object streams if mixed with non-object ones', testHighWaterMarkAmount, false, true, 2);
+test('"highWaterMark" is the maximum of non-object input streams', testHighWaterMarkAmount, false, false, 4);
+test('"highWaterMark" is the maximum of object input streams', testHighWaterMarkAmount, true, true, 4);
+test('"highWaterMark" is the maximum of object streams if mixed with non-object ones', testHighWaterMarkAmount, false, true, 2);
 
-test('add() cannot change highWaterMark', async t => {
+test('"add()" cannot change highWaterMark', async t => {
 	const stream = mergeStreams([Readable.from('.', {highWaterMark: 2})]);
 	stream.add(Readable.from('.', {highWaterMark: 4}));
 	t.is(stream.readableHighWaterMark, 2);
@@ -394,13 +394,13 @@ test('Only increments maxListeners of input streams by 2', async t => {
 	await stream.toArray();
 });
 
-test('can add stream after no streams have ended', async t => {
+test('Can add stream after no streams have ended', async t => {
 	const stream = mergeStreams([Readable.from('.')]);
 	stream.add(Readable.from('.'));
 	t.is(await text(stream), '..');
 });
 
-test('can add stream after some streams but not all streams have ended', async t => {
+test('Can add stream after some streams but not all streams have ended', async t => {
 	const inputStream = Readable.from('.');
 	const pendingStream = new PassThrough();
 	const stream = mergeStreams([inputStream, pendingStream]);
@@ -410,7 +410,7 @@ test('can add stream after some streams but not all streams have ended', async t
 	t.is(await text(stream), '...');
 });
 
-test('cannot add stream after all streams have ended', async t => {
+test('Cannot add stream after all streams have ended', async t => {
 	const stream = mergeStreams([Readable.from('.')]);
 	t.is(await text(stream), '.');
 	const inputStream = Readable.from('.');
@@ -420,14 +420,14 @@ test('cannot add stream after all streams have ended', async t => {
 	await stream.toArray();
 });
 
-test('adding same stream twice is a noop', async t => {
+test('Adding same stream twice is a noop', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([inputStream]);
 	stream.add(inputStream);
 	t.is(await text(stream), '.');
 });
 
-test('can remove stream before it ends', async t => {
+test('Can remove stream before it ends', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([Readable.from('.'), inputStream]);
 	stream.remove(inputStream);
@@ -435,7 +435,7 @@ test('can remove stream before it ends', async t => {
 	t.is(await text(stream), '.');
 });
 
-test('can remove stream after it ends', async t => {
+test('Can remove stream after it ends', async t => {
 	const inputStream = Readable.from('.');
 	const pendingStream = new PassThrough();
 	const stream = mergeStreams([pendingStream, inputStream]);
@@ -445,7 +445,7 @@ test('can remove stream after it ends', async t => {
 	t.is(await text(stream), '. ');
 });
 
-test('can remove stream after other streams have ended', async t => {
+test('Can remove stream after other streams have ended', async t => {
 	const inputStream = Readable.from('.');
 	const pendingStream = new PassThrough();
 	const stream = mergeStreams([pendingStream, inputStream]);
@@ -456,14 +456,14 @@ test('can remove stream after other streams have ended', async t => {
 	pendingStream.end();
 });
 
-test('can remove stream until no input', async t => {
+test('Can remove stream until no input', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([inputStream]);
 	stream.remove(inputStream);
 	t.is(await text(stream), '');
 });
 
-test('can remove then add again a stream', async t => {
+test('Can remove then add again a stream', async t => {
 	const pendingStream = new PassThrough();
 	const secondPendingStream = new PassThrough();
 	const stream = mergeStreams([pendingStream, secondPendingStream]);
@@ -484,7 +484,7 @@ test('can remove then add again a stream', async t => {
 	t.is(await streamPromise, '...');
 });
 
-test('cannot remove same stream twice', async t => {
+test('Cannot remove same stream twice', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([inputStream]);
 	stream.remove(inputStream);
@@ -503,10 +503,10 @@ const testInvalidRemove = async (t, removeArgument) => {
 	await stream.toArray();
 };
 
-test('cannot remove stream if not piped', testInvalidRemove, Readable.from('.'));
-test('cannot pass a non-stream to remove()', testInvalidRemove, '.');
-test('cannot pass undefined to remove()', testInvalidRemove, undefined);
-test('cannot pass null to remove()', testInvalidRemove, null);
+test('Cannot remove stream if not piped', testInvalidRemove, Readable.from('.'));
+test('Cannot pass a non-stream to remove()', testInvalidRemove, '.');
+test('Cannot pass undefined to remove()', testInvalidRemove, undefined);
+test('Cannot pass null to remove()', testInvalidRemove, null);
 
 test('PassThrough streams methods are not overridden', t => {
 	t.is(PassThrough.prototype.add, undefined);

--- a/test.js
+++ b/test.js
@@ -477,6 +477,17 @@ test('can remove then add again a stream', async t => {
 	t.is(await streamPromise, '...');
 });
 
+test('cannot remove same stream twice', async t => {
+	const inputStream = Readable.from('.');
+	const stream = mergeStreams([inputStream]);
+	stream.remove(inputStream);
+	await scheduler.yield();
+	t.throws(() => {
+		stream.remove(inputStream);
+	}, {message: /cannot be removed/});
+	await stream.toArray();
+});
+
 const testInvalidRemove = async (t, removeArgument) => {
 	const stream = mergeStreams([Readable.from('.')]);
 	t.throws(() => {

--- a/test.js
+++ b/test.js
@@ -420,6 +420,15 @@ test('cannot add stream after all streams have ended', async t => {
 	await stream.toArray();
 });
 
+test('cannot add same stream twice', async t => {
+	const inputStream = Readable.from('.');
+	const stream = mergeStreams([inputStream]);
+	t.throws(() => {
+		stream.add(inputStream);
+	}, {message: /cannot be added/});
+	await stream.toArray();
+});
+
 test('can remove stream before it ends', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([Readable.from('.'), inputStream]);

--- a/test.js
+++ b/test.js
@@ -420,13 +420,11 @@ test('cannot add stream after all streams have ended', async t => {
 	await stream.toArray();
 });
 
-test('cannot add same stream twice', async t => {
+test('adding same stream twice is a noop', async t => {
 	const inputStream = Readable.from('.');
 	const stream = mergeStreams([inputStream]);
-	t.throws(() => {
-		stream.add(inputStream);
-	}, {message: /cannot be added/});
-	await stream.toArray();
+	stream.add(inputStream);
+	t.is(await text(stream), '.');
 });
 
 test('can remove stream before it ends', async t => {


### PR DESCRIPTION
This allows dynamically adding or removing streams to merge.

This is something that is needed for Execa with the upcoming improvements of `childProcess.pipe(secondProcess)` to allow multiple processes (or multiple streams of one process) to pipe into the same process (as part of https://github.com/sindresorhus/execa/issues/745).

The adds two methods to the returned `PassThrough`: `.add(stream)` and `.remove(stream)`.