### PR TITLE
Fix `maxListeners` edge case

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,10 @@ const onInputStreamUnpipe = async ({passThroughStream, stream, streams, ended, a
 const unpipeEvent = Symbol('unpipe');
 
 const updateMaxListeners = (passThroughStream, increment) => {
-	passThroughStream.setMaxListeners(passThroughStream.getMaxListeners() + increment);
+	const maxListeners = passThroughStream.getMaxListeners();
+	if (maxListeners !== 0 && maxListeners !== Number.POSITIVE_INFINITY) {
+		passThroughStream.setMaxListeners(maxListeners + increment);
+	}
 };
 
 // Number of times `passThroughStream.on()` is called regardless of streams:

--- a/test.js
+++ b/test.js
@@ -416,18 +416,21 @@ test('Updates maxListeners of merged streams with add() and remove()', async t =
 	t.is(stream.getMaxListeners(), defaultMaxListeners);
 });
 
-test('Handles setting maxListeners to Infinity', async t => {
+const testInfiniteMaxListeners = async (t, maxListeners) => {
 	const stream = mergeStreams([Readable.from('.')]);
-	stream.setMaxListeners(Number.POSITIVE_INFINITY);
-	t.is(stream.getMaxListeners(), Number.POSITIVE_INFINITY);
+	stream.setMaxListeners(maxListeners);
+	t.is(stream.getMaxListeners(), maxListeners);
 
 	stream.add(Readable.from('.'));
-	t.is(stream.getMaxListeners(), Number.POSITIVE_INFINITY);
+	t.is(stream.getMaxListeners(), maxListeners);
 
 	await stream.toArray();
 	await scheduler.yield();
-	t.is(stream.getMaxListeners(), Number.POSITIVE_INFINITY);
-});
+	t.is(stream.getMaxListeners(), maxListeners);
+};
+
+test('Handles setting maxListeners to Infinity', testInfiniteMaxListeners, Number.POSITIVE_INFINITY);
+test('Handles setting maxListeners to 0', testInfiniteMaxListeners, 0);
 
 test('Only increments maxListeners of input streams by 2', async t => {
 	const inputStream = Readable.from('.');


### PR DESCRIPTION
This fixes the edge case of setting the merged stream's `maxListeners` to `0`.

I have no pending PRs after this one, i.e. this will be ready for release. :+1: 