### PR TITLE
Make `.remove()` async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,5 +40,5 @@ export class MergedStream extends Readable {
 
 	The removed stream is not automatically ended.
 	*/
-	remove(stream: Readable): boolean;
+	remove(stream: Readable): Promise<boolean>;
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,7 @@ expectError(mergedStream.add());
 expectError(mergedStream.add([]));
 expectError(mergedStream.add(''));
 
-expectType<boolean>(mergedStream.remove(readableStream));
-expectError(mergedStream.remove());
-expectError(mergedStream.remove([]));
-expectError(mergedStream.remove(''));
+expectType<Promise<boolean>>(mergedStream.remove(readableStream));
+expectError(await mergedStream.remove());
+expectError(await mergedStream.remove([]));
+expectError(await mergedStream.remove(''));

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Pipe a new readable stream.
 
 Throws if `MergedStream` has already ended.
 
-##### `MergedStream.remove(stream: stream.Readable): boolean`
+##### `MergedStream.remove(stream: stream.Readable): Promise<boolean>`
 
 Unpipe a stream previously added using either [`mergeStreams(streams)`](#mergestreamsstreams-streamreadable-mergedstream) or [`MergedStream.add(stream)`](#mergedstreamaddstream-streamreadable-void).
 


### PR DESCRIPTION
Fixes #39.

The `.remove()` method requires multiple ticks to complete. It needs to be `async`. Otherwise, this creates race conditions, e.g. when calling `.add()` right after `.remove()`.